### PR TITLE
Added NonManagedCopy extension method to Realm collections

### DIFF
--- a/src/RealmJson.Extensions/Extension.cs
+++ b/src/RealmJson.Extensions/Extension.cs
@@ -321,24 +321,59 @@ namespace SushiHangover.RealmJson
 			return realmObjectCopy;
 		}
 
-		//void createOrUpdateAllFromJson(Class<E> clazz, InputStream in)
-		//Tries to update a list of existing objects identified by their primary key with new JSON data.
-		//<E extends RealmModel>
-		//void createOrUpdateAllFromJson(Class<E> clazz, org.json.JSONArray json)
-		//Tries to update a list of existing objects identified by their primary key with new JSON data.
-		//<E extends RealmModel>
-		//void createOrUpdateAllFromJson(Class<E> clazz, String json)
-		//Tries to update a list of existing objects identified by their primary key with new JSON data.
-		//<E extends RealmModel>
+        /// <summary>
+        /// Create a non-managed copy of Realm's Query Result.
+        /// </summary>
+        /// <param name="results">Realm collection</param>
+        /// <typeparam name="T">Type of the <see cref="RealmObject"/> in the results.</typeparam>
+        /// <returns>The collection of non-managed realm objects.</returns>
+        public static IQueryable<T> NonManagedCopy<T>(this IQueryable<T> results) where T : RealmObject
+        {
+            var realmCollectionCopy = CopyRealmCollectionElements(results);
+            return realmCollectionCopy.AsQueryable();
+        }
 
-		//E createOrUpdateObjectFromJson(Class<E> clazz, InputStream in)
-		//Tries to update an existing object defined by its primary key with new JSON data.
-		//<E extends RealmModel>
-		//E createOrUpdateObjectFromJson(Class<E> clazz, org.json.JSONObject json)
-		//Tries to update an existing object defined by its primary key with new JSON data.
-		//<E extends RealmModel>
-		//E createOrUpdateObjectFromJson(Class<E> clazz, String json)
-		//Tries to update an existing object defined by its primary key with new JSON data.
+        /// <summary>
+        /// Create a non-managed copy of Realm's Query Result.
+        /// </summary>
+        /// <param name="results">Realm collection</param>
+        /// <typeparam name="T">Type of the <see cref="RealmObject"/> in the results.</typeparam>
+        /// <returns>The collection of non-managed realm objects.</returns>
+        public static IList<T> NonManagedCopy<T>(this IList<T> list) where T : RealmObject
+        {
+            return CopyRealmCollectionElements(list);
+        }
 
-	}
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static IList<T> CopyRealmCollectionElements<T>(IEnumerable<T> collection) where T : RealmObject
+        {
+            var realmCollectionCopy = new List<T>();
+            foreach (var element in collection)
+            {
+                var nonManagedElementCopy = NonManagedCopy<T>(element);
+                realmCollectionCopy.Add(nonManagedElementCopy);
+            }
+            return realmCollectionCopy;
+        }
+
+        //void createOrUpdateAllFromJson(Class<E> clazz, InputStream in)
+        //Tries to update a list of existing objects identified by their primary key with new JSON data.
+        //<E extends RealmModel>
+        //void createOrUpdateAllFromJson(Class<E> clazz, org.json.JSONArray json)
+        //Tries to update a list of existing objects identified by their primary key with new JSON data.
+        //<E extends RealmModel>
+        //void createOrUpdateAllFromJson(Class<E> clazz, String json)
+        //Tries to update a list of existing objects identified by their primary key with new JSON data.
+        //<E extends RealmModel>
+
+        //E createOrUpdateObjectFromJson(Class<E> clazz, InputStream in)
+        //Tries to update an existing object defined by its primary key with new JSON data.
+        //<E extends RealmModel>
+        //E createOrUpdateObjectFromJson(Class<E> clazz, org.json.JSONObject json)
+        //Tries to update an existing object defined by its primary key with new JSON data.
+        //<E extends RealmModel>
+        //E createOrUpdateObjectFromJson(Class<E> clazz, String json)
+        //Tries to update an existing object defined by its primary key with new JSON data.
+
+    }
 }

--- a/src/RealmJson.Extensions/Extension.cs
+++ b/src/RealmJson.Extensions/Extension.cs
@@ -321,59 +321,59 @@ namespace SushiHangover.RealmJson
 			return realmObjectCopy;
 		}
 
-        /// <summary>
-        /// Create a non-managed copy of Realm's Query Result.
-        /// </summary>
-        /// <param name="results">Realm collection</param>
-        /// <typeparam name="T">Type of the <see cref="RealmObject"/> in the results.</typeparam>
-        /// <returns>The collection of non-managed realm objects.</returns>
-        public static IQueryable<T> NonManagedCopy<T>(this IQueryable<T> results) where T : RealmObject
-        {
-            var realmCollectionCopy = CopyRealmCollectionElements(results);
-            return realmCollectionCopy.AsQueryable();
-        }
+		/// <summary>
+		/// Create a non-managed copy of Realm's Query Result.
+		/// </summary>
+		/// <param name="results">Realm collection</param>
+		/// <typeparam name="T">Type of the <see cref="RealmObject"/> in the results.</typeparam>
+		/// <returns>The collection of non-managed realm objects.</returns>
+		public static IQueryable<T> NonManagedCopy<T>(this IQueryable<T> results) where T : RealmObject
+		{
+			var realmCollectionCopy = CopyRealmCollectionElements(results);
+			return realmCollectionCopy.AsQueryable();
+		}
 
-        /// <summary>
-        /// Create a non-managed copy of Realm's Query Result.
-        /// </summary>
-        /// <param name="results">Realm collection</param>
-        /// <typeparam name="T">Type of the <see cref="RealmObject"/> in the results.</typeparam>
-        /// <returns>The collection of non-managed realm objects.</returns>
-        public static IList<T> NonManagedCopy<T>(this IList<T> list) where T : RealmObject
-        {
-            return CopyRealmCollectionElements(list);
-        }
+		/// <summary>
+		/// Create a non-managed copy of Realm's Query Result.
+		/// </summary>
+		/// <param name="results">Realm collection</param>
+		/// <typeparam name="T">Type of the <see cref="RealmObject"/> in the results.</typeparam>
+		/// <returns>The collection of non-managed realm objects.</returns>
+		public static IList<T> NonManagedCopy<T>(this IList<T> list) where T : RealmObject
+		{
+			return CopyRealmCollectionElements(list);
+		}
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static IList<T> CopyRealmCollectionElements<T>(IEnumerable<T> collection) where T : RealmObject
-        {
-            var realmCollectionCopy = new List<T>();
-            foreach (var element in collection)
-            {
-                var nonManagedElementCopy = NonManagedCopy<T>(element);
-                realmCollectionCopy.Add(nonManagedElementCopy);
-            }
-            return realmCollectionCopy;
-        }
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		static IList<T> CopyRealmCollectionElements<T>(IEnumerable<T> collection) where T : RealmObject
+		{
+			var realmCollectionCopy = new List<T>();
+			foreach (var element in collection)
+			{
+				var nonManagedElementCopy = NonManagedCopy<T>(element);
+				realmCollectionCopy.Add(nonManagedElementCopy);
+			}
+			return realmCollectionCopy;
+		}
 
-        //void createOrUpdateAllFromJson(Class<E> clazz, InputStream in)
-        //Tries to update a list of existing objects identified by their primary key with new JSON data.
-        //<E extends RealmModel>
-        //void createOrUpdateAllFromJson(Class<E> clazz, org.json.JSONArray json)
-        //Tries to update a list of existing objects identified by their primary key with new JSON data.
-        //<E extends RealmModel>
-        //void createOrUpdateAllFromJson(Class<E> clazz, String json)
-        //Tries to update a list of existing objects identified by their primary key with new JSON data.
-        //<E extends RealmModel>
+		//void createOrUpdateAllFromJson(Class<E> clazz, InputStream in)
+		//Tries to update a list of existing objects identified by their primary key with new JSON data.
+		//<E extends RealmModel>
+		//void createOrUpdateAllFromJson(Class<E> clazz, org.json.JSONArray json)
+		//Tries to update a list of existing objects identified by their primary key with new JSON data.
+		//<E extends RealmModel>
+		//void createOrUpdateAllFromJson(Class<E> clazz, String json)
+		//Tries to update a list of existing objects identified by their primary key with new JSON data.
+		//<E extends RealmModel>
 
-        //E createOrUpdateObjectFromJson(Class<E> clazz, InputStream in)
-        //Tries to update an existing object defined by its primary key with new JSON data.
-        //<E extends RealmModel>
-        //E createOrUpdateObjectFromJson(Class<E> clazz, org.json.JSONObject json)
-        //Tries to update an existing object defined by its primary key with new JSON data.
-        //<E extends RealmModel>
-        //E createOrUpdateObjectFromJson(Class<E> clazz, String json)
-        //Tries to update an existing object defined by its primary key with new JSON data.
+		//E createOrUpdateObjectFromJson(Class<E> clazz, InputStream in)
+		//Tries to update an existing object defined by its primary key with new JSON data.
+		//<E extends RealmModel>
+		//E createOrUpdateObjectFromJson(Class<E> clazz, org.json.JSONObject json)
+		//Tries to update an existing object defined by its primary key with new JSON data.
+		//<E extends RealmModel>
+		//E createOrUpdateObjectFromJson(Class<E> clazz, String json)
+		//Tries to update an existing object defined by its primary key with new JSON data.
 
-    }
+	}
 }

--- a/src/RealmJson.Shared.Tests/Tests.Shared.cs
+++ b/src/RealmJson.Shared.Tests/Tests.Shared.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -8,348 +9,411 @@ using SushiHangover.RealmJson;
 
 namespace RealmJson.Test
 {
-	[TestFixture]
-	public partial class Tests
-	{
-		const string jsonStringSingleState = @"
+    [TestFixture]
+    public partial class Tests
+    {
+        const string jsonStringSingleState = @"
 {
-    ""name"": ""Alabama"",
-    ""abbreviation"": ""AL""
+	""name"": ""Alabama"",
+	""abbreviation"": ""AL""
 }
 ";
 
-		const string jsonStringTwoState = @"
+        const string jsonStringTwoState = @"
 [
-    {
-        ""name"": ""Alabama"",
-        ""abbreviation"": ""AL""
-    },
+	{
+		""name"": ""Alabama"",
+		""abbreviation"": ""AL""
+	},
 {
-        ""name"": ""Wyoming"",
-        ""abbreviation"": ""WY""
-    }
+		""name"": ""Wyoming"",
+		""abbreviation"": ""WY""
+	}
 ]
 ";
 
-		const string jsonStringThreeState = @"
+        const string jsonStringThreeState = @"
 [
-    {
-        ""name"": ""Alabama"",
-        ""abbreviation"": ""AL""
-    },
-    {
-        ""name"": ""Oklahoma"",
-        ""abbreviation"": ""OK""
-    },
-    {
-        ""name"": ""Wyoming"",
-        ""abbreviation"": ""WY""
-    }
+	{
+		""name"": ""Alabama"",
+		""abbreviation"": ""AL""
+	},
+	{
+		""name"": ""Oklahoma"",
+		""abbreviation"": ""OK""
+	},
+	{
+		""name"": ""Wyoming"",
+		""abbreviation"": ""WY""
+	}
 ]
 ";
 
-		public void DeleteRealmDB(string realmDBFullPath)
-		{
-			if (File.Exists(realmDBFullPath))
-			{
-				File.Delete(realmDBFullPath);
-			}
-		}
+        public void DeleteRealmDB(string realmDBFullPath)
+        {
+            if (File.Exists(realmDBFullPath))
+            {
+                File.Delete(realmDBFullPath);
+            }
+        }
 
-		string RealmDBTempPath()
-		{
-			return Path.GetTempFileName();
-		}
+        string RealmDBTempPath()
+        {
+            return Path.GetTempFileName();
+        }
 
-		[SetUp]
-		public void Setup()
-		{
-		}
+        [SetUp]
+        public void Setup()
+        {
+        }
 
-		[TearDown]
-		public void Tear()
-		{
-		}
+        [TearDown]
+        public void Tear()
+        {
+        }
 
 #if !PERF
 
-		[Test]
-		public void CreateObjectFromJson_String()
-		{
-			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-			{
-				var testObject = theRealm.CreateObjectFromJson<StateUnique>(jsonStringSingleState);
-				Assert.IsTrue(testObject.abbreviation == "AL" & testObject.name == "Alabama");
-			}
-		}
+        [Test]
+        public void CreateObjectFromJson_String()
+        {
+            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+            {
+                var testObject = theRealm.CreateObjectFromJson<StateUnique>(jsonStringSingleState);
+                Assert.IsTrue(testObject.abbreviation == "AL" & testObject.name == "Alabama");
+            }
+        }
 
-		[Test]
-		public void CreateObjectFromJson_InTransaction_Stream()
-		{
-			byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringSingleState);
-			using (var stream = new MemoryStream(byteArray))
-			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-			{
-				StateUnique testObject;
-				using (var transaction = theRealm.BeginWrite())
+        [Test]
+        public void CreateObjectFromJson_InTransaction_Stream()
+        {
+            byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringSingleState);
+            using (var stream = new MemoryStream(byteArray))
+            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+            {
+                StateUnique testObject;
+                using (var transaction = theRealm.BeginWrite())
+                {
+                    testObject = theRealm.CreateObjectFromJson<StateUnique>(stream, inTransaction: true);
+                    transaction.Commit();
+                }
+                Assert.IsTrue(testObject.abbreviation == "AL" & testObject.name == "Alabama");
+            }
+        }
+
+        [Test]
+        public void CreateObjectFromJson_InTransaction_RollBack_Stream()
+        {
+            byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringSingleState);
+            using (var stream = new MemoryStream(byteArray))
+            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+            {
+                using (var transaction = theRealm.BeginWrite())
+                {
+                    theRealm.CreateObjectFromJson<StateUnique>(stream, inTransaction: true);
+                    transaction.Rollback();
+                }
+                Assert.IsTrue(theRealm.Find<StateUnique>("AL") == null);
+            }
+        }
+
+        [Test]
+        public void CreateObjectFromJson_Stream()
+        {
+            byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringSingleState);
+            using (var stream = new MemoryStream(byteArray))
+            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+            {
+                var testObject = theRealm.CreateObjectFromJson<StateUnique>(stream);
+                Assert.IsTrue(testObject.abbreviation == "AL" & testObject.name == "Alabama");
+            }
+        }
+
+        public string CreateTestDBFromJson(string jsonString)
+        {
+            var dbFile = RealmDBTempPath();
+            using (var theRealm = Realm.GetInstance(dbFile))
+            {
+                theRealm.CreateAllFromJson<StateUnique>(jsonString);
+            }
+            return dbFile;
+        }
+
+        [Test]
+        public void CreateOrUpdateObjectFromJson_Create_PKisString_String()
+        {
+            var jsonString = @"
 				{
-					testObject = theRealm.CreateObjectFromJson<StateUnique>(stream, inTransaction: true);
-					transaction.Commit();
-				}
-				Assert.IsTrue(testObject.abbreviation == "AL" & testObject.name == "Alabama");
-			}
-		}
-
-		[Test]
-		public void CreateObjectFromJson_InTransaction_RollBack_Stream()
-		{
-			byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringSingleState);
-			using (var stream = new MemoryStream(byteArray))
-			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-			{
-				using (var transaction = theRealm.BeginWrite())
-				{
-					theRealm.CreateObjectFromJson<StateUnique>(stream, inTransaction: true);
-					transaction.Rollback();
-				}
-				Assert.IsTrue(theRealm.Find<StateUnique>("AL") == null);
-			}
-		}
-
-		[Test]
-		public void CreateObjectFromJson_Stream()
-		{
-			byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringSingleState);
-			using (var stream = new MemoryStream(byteArray))
-			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-			{
-				var testObject = theRealm.CreateObjectFromJson<StateUnique>(stream);
-				Assert.IsTrue(testObject.abbreviation == "AL" & testObject.name == "Alabama");
-			}
-		}
-
-		public string CreateTestDBFromJson(string jsonString)
-		{
-			var dbFile = RealmDBTempPath();
-			using (var theRealm = Realm.GetInstance(dbFile))
-			{
-				theRealm.CreateAllFromJson<StateUnique>(jsonString);
-			}
-			return dbFile;
-		}
-
-		[Test]
-		public void CreateOrUpdateObjectFromJson_Create_PKisString_String()
-		{
-			var jsonString = @"
-				{
-				    ""name"": ""NEW"",
-				    ""abbreviation"": ""NW""
+					""name"": ""NEW"",
+					""abbreviation"": ""NW""
 				}";
-			var dbFile = CreateTestDBFromJson(jsonStringTwoState);
+            var dbFile = CreateTestDBFromJson(jsonStringTwoState);
 
-			using (var theRealm = Realm.GetInstance(dbFile))
-			{
-				var realmObject = theRealm.CreateOrUpdateObjectFromJson<StateUnique>(jsonString);
-				Assert.IsTrue(realmObject.abbreviation == "NW" & realmObject.name == "NEW");
-			}
-		}
+            using (var theRealm = Realm.GetInstance(dbFile))
+            {
+                var realmObject = theRealm.CreateOrUpdateObjectFromJson<StateUnique>(jsonString);
+                Assert.IsTrue(realmObject.abbreviation == "NW" & realmObject.name == "NEW");
+            }
+        }
 
-		[Test]
-		public void CreateOrUpdateObjectFromJson_Update_PKisString_String()
-		{
-			var jsonString = @"
+        [Test]
+        public void CreateOrUpdateObjectFromJson_Update_PKisString_String()
+        {
+            var jsonString = @"
 				{
-				    ""name"": ""UPDATED"",
-				    ""abbreviation"": ""OK""
+					""name"": ""UPDATED"",
+					""abbreviation"": ""OK""
 				}";
 
-			var dbFile = CreateTestDBFromJson(jsonStringThreeState);
+            var dbFile = CreateTestDBFromJson(jsonStringThreeState);
 
-			using (var theRealm = Realm.GetInstance(dbFile))
-			{
-				var realmObject = theRealm.CreateOrUpdateObjectFromJson<StateUnique>(jsonString);
-				Assert.IsTrue(realmObject.name == "UPDATED");
-			}
-		}
+            using (var theRealm = Realm.GetInstance(dbFile))
+            {
+                var realmObject = theRealm.CreateOrUpdateObjectFromJson<StateUnique>(jsonString);
+                Assert.IsTrue(realmObject.name == "UPDATED");
+            }
+        }
 
-		[Test]
-		public void CreateAllFromJson_String()
-		{
-			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-			{
-				theRealm.CreateAllFromJson<StateUnique>(jsonStringThreeState);
-				Assert.AreEqual(3, theRealm.All<StateUnique>().Count());
-			}
-		}
+        [Test]
+        public void CreateAllFromJson_String()
+        {
+            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+            {
+                theRealm.CreateAllFromJson<StateUnique>(jsonStringThreeState);
+                Assert.AreEqual(3, theRealm.All<StateUnique>().Count());
+            }
+        }
 
-		[Test]
-		public void CreateAllFromJson_Stream()
-		{
-			byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringTwoState);
-			using (var stream = new MemoryStream(byteArray))
-			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-			{
-				theRealm.CreateAllFromJson<StateUnique>(stream);
-				Assert.AreEqual(2, theRealm.All<StateUnique>().Count());
+        [Test]
+        public void CreateAllFromJson_Stream()
+        {
+            byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringTwoState);
+            using (var stream = new MemoryStream(byteArray))
+            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+            {
+                theRealm.CreateAllFromJson<StateUnique>(stream);
+                Assert.AreEqual(2, theRealm.All<StateUnique>().Count());
 
-				// Did the records get created properly from the steam?
-				Assert.IsTrue(theRealm.All<StateUnique>().Where((StateUnique s) => s.abbreviation == "AL").Any());
-				Assert.IsTrue(theRealm.All<StateUnique>().Last().abbreviation == "WY");
-			}
-		}
+                // Did the records get created properly from the steam?
+                Assert.IsTrue(theRealm.All<StateUnique>().Where((StateUnique s) => s.abbreviation == "AL").Any());
+                Assert.IsTrue(theRealm.All<StateUnique>().Last().abbreviation == "WY");
+            }
+        }
 
-		[Test]
-		public void CreateAllFromJsonViaAutoMapperFromJson__NewRecords_Stream()
-		{
-			byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringTwoState);
-			using (var stream = new MemoryStream(byteArray))
-			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-			{
-				theRealm.CreateAllFromJsonViaAutoMapper<StateUnique>(stream);
-				Assert.AreEqual(2, theRealm.All<StateUnique>().Count());
+        [Test]
+        public void CreateAllFromJsonViaAutoMapperFromJson__NewRecords_Stream()
+        {
+            byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringTwoState);
+            using (var stream = new MemoryStream(byteArray))
+            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+            {
+                theRealm.CreateAllFromJsonViaAutoMapper<StateUnique>(stream);
+                Assert.AreEqual(2, theRealm.All<StateUnique>().Count());
 
-				// Did the records get AutoMapped properly from the steam?
-				Assert.IsTrue(theRealm.All<StateUnique>().Where((StateUnique s) => s.abbreviation == "AL").Any());
-				Assert.IsTrue(theRealm.All<StateUnique>().Last().abbreviation == "WY");
-			}
-		}
+                // Did the records get AutoMapped properly from the steam?
+                Assert.IsTrue(theRealm.All<StateUnique>().Where((StateUnique s) => s.abbreviation == "AL").Any());
+                Assert.IsTrue(theRealm.All<StateUnique>().Last().abbreviation == "WY");
+            }
+        }
 
-		[Test]
-		public void CreateAllFromJsonViaAutoMapperFromJson__UpdateRecords_Stream()
-		{
-			var dbFile = CreateTestDBFromJson(jsonStringTwoState);
-			byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringThreeState);
-			using (var stream = new MemoryStream(byteArray))
-			using (var theRealm = Realm.GetInstance(dbFile))
-			{
-				Assert.AreEqual(2, theRealm.All<StateUnique>().Count());
-				theRealm.CreateAllFromJsonViaAutoMapper<StateUnique>(stream);
-				Assert.AreEqual(3, theRealm.All<StateUnique>().Count());
+        [Test]
+        public void CreateAllFromJsonViaAutoMapperFromJson__UpdateRecords_Stream()
+        {
+            var dbFile = CreateTestDBFromJson(jsonStringTwoState);
+            byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringThreeState);
+            using (var stream = new MemoryStream(byteArray))
+            using (var theRealm = Realm.GetInstance(dbFile))
+            {
+                Assert.AreEqual(2, theRealm.All<StateUnique>().Count());
+                theRealm.CreateAllFromJsonViaAutoMapper<StateUnique>(stream);
+                Assert.AreEqual(3, theRealm.All<StateUnique>().Count());
 
-				// Did the "new" record get AutoMapped properly from the steam?
-				Assert.IsTrue(theRealm.All<StateUnique>().Where((StateUnique s) => s.abbreviation == "OK").Any());
-			}
-		}
+                // Did the "new" record get AutoMapped properly from the steam?
+                Assert.IsTrue(theRealm.All<StateUnique>().Where((StateUnique s) => s.abbreviation == "OK").Any());
+            }
+        }
 
-		[Test]
-		public void CreateAllFromJsonViaAutoMapperFromJson__UpdateRecords__InTrans_Stream()
-		{
-			var dbFile = CreateTestDBFromJson(jsonStringTwoState);
-			byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringThreeState);
-			using (var stream = new MemoryStream(byteArray))
-			using (var theRealm = Realm.GetInstance(dbFile))
-			{
-				Assert.AreEqual(2, theRealm.All<StateUnique>().Count());
-				using (var transaction = theRealm.BeginWrite())
-				{
-					theRealm.CreateAllFromJsonViaAutoMapper<StateUnique>(stream, true);
-					transaction.Commit();
-				}
-				Assert.AreEqual(3, theRealm.All<StateUnique>().Count());
-				// Did the "new" record get AutoMapped properly from the steam?
-				Assert.IsTrue(theRealm.All<StateUnique>().Where((StateUnique s) => s.abbreviation == "OK").Any());
-			}
-		}
+        [Test]
+        public void CreateAllFromJsonViaAutoMapperFromJson__UpdateRecords__InTrans_Stream()
+        {
+            var dbFile = CreateTestDBFromJson(jsonStringTwoState);
+            byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringThreeState);
+            using (var stream = new MemoryStream(byteArray))
+            using (var theRealm = Realm.GetInstance(dbFile))
+            {
+                Assert.AreEqual(2, theRealm.All<StateUnique>().Count());
+                using (var transaction = theRealm.BeginWrite())
+                {
+                    theRealm.CreateAllFromJsonViaAutoMapper<StateUnique>(stream, true);
+                    transaction.Commit();
+                }
+                Assert.AreEqual(3, theRealm.All<StateUnique>().Count());
+                // Did the "new" record get AutoMapped properly from the steam?
+                Assert.IsTrue(theRealm.All<StateUnique>().Where((StateUnique s) => s.abbreviation == "OK").Any());
+            }
+        }
 
-		[Test]
-		public void CreateAllFromJson_InvalidStream()
-		{
-			var jsonStringInvalid = @"";
-			byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringInvalid);
-			using (var stream = new MemoryStream(byteArray))
-			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-			{
-				Assert.That(() => theRealm.CreateAllFromJson<StateUnique>(stream),
-					Throws.Exception
-						.TypeOf<Exception>()
-						.With.Property("Message")
-						.EqualTo(RealmDoesJson.ExMalFormeJsonMessage)
-	           );
-			}
-		}
+        [Test]
+        public void CreateAllFromJson_InvalidStream()
+        {
+            var jsonStringInvalid = @"";
+            byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringInvalid);
+            using (var stream = new MemoryStream(byteArray))
+            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+            {
+                Assert.That(() => theRealm.CreateAllFromJson<StateUnique>(stream),
+                    Throws.Exception
+                        .TypeOf<Exception>()
+                        .With.Property("Message")
+                        .EqualTo(RealmDoesJson.ExMalFormeJsonMessage)
+               );
+            }
+        }
+        [Test]
+        public void NonManagedCollectionCopyFromNonManagedGenericType()
+        {
+            var nonManagedCollection = CreateTestCollection();
+            var nonManagedCollectionCopy = nonManagedCollection.NonManagedCopy();
+            Assert.False(nonManagedCollectionCopy.All(element => element.IsManaged));
+            Assert.True(EnumerablesAreEqual(nonManagedCollectionCopy, nonManagedCollection));
+        }
 
-		[Test]
-		public void NonManagedCopyFromNonManagedGenericType()
-		{
-			var obj1 = new State
-			{
-				name = "ZZ",
-				abbreviation = "Z"
-			};
-			var obj2 = obj1.NonManagedCopy<State>();
-			Assert.False(obj2.IsManaged);
-			// Non-managed objects are never equivalate, this RealmObject.Equals can not be used
-			Assert.AreEqual(obj1.abbreviation, obj2.abbreviation);
-			Assert.AreEqual(obj1.name, obj2.name);
-		}
+        [Test]
+        public void NonManagedCollectionCopyFromManagedGenericType()
+        {
+            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+            {
+                theRealm.Write(() =>
+                {
+                    var nonManagedCollection = CreateTestCollection();
+                    foreach (var item in nonManagedCollection)
+                    {
+                        theRealm.Add(item);
+                    }
+                });
 
-		[Test]
-		public void NonManagedCopyFromNonManagedRealmObjectType()
-		{
-			var obj1 = new State
-			{
-				name = "ZZ",
-				abbreviation = "Z"
-			};
-			var obj2 = obj1.NonManagedCopy();
-			var obj3 = obj2 as State;
-			// Non-managed objects are never equivalate, this RealmObject.Equals can not be used
-			Assert.False(obj3.IsManaged);
-			Assert.AreEqual(obj1.abbreviation, obj3.abbreviation);
-			Assert.AreEqual(obj1.name, obj3.name);
-		}
+                var managedCollection = theRealm.All<State>();
 
-		[Test]
-		public void NonManagedCopyFromManagedGenericType()
-		{
-			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-			{
-				State obj1 = null;
-				theRealm.Write(() =>
-				{
-					var tmp = new State
-					{
-						name = "ZZ",
-						abbreviation = "Z"
-					};
-					obj1 = theRealm.Add(tmp);
-				});
-				Assert.True(obj1.IsManaged);
-				var obj2 = obj1.NonManagedCopy<State>();
-				// Non-managed objects are never equivalate, this RealmObject.Equals can not be used
-				Assert.False(obj2.IsManaged);
-				Assert.AreEqual(obj1.abbreviation, obj2.abbreviation);
-				Assert.AreEqual(obj1.name, obj2.name);
-			}
-		}
+                foreach (var managedObject in managedCollection)
+                {
+                    Assert.True(managedObject.IsManaged);
+                }
 
-		[Test]
-		public void NonManagedCopyFromManagedRealmObjectType()
-		{
-			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-			{
-				State obj1 = null;
-				theRealm.Write(() =>
-				{
-					var tmp = new State
-					{
-						name = "ZZ",
-						abbreviation = "Z"
-					};
-					obj1 = theRealm.Add(tmp);
-				});
-				Assert.True(obj1.IsManaged);
-				var obj2 = obj1.NonManagedCopy() as State;
-				// Non-managed objects are never equivalate, this RealmObject.Equals can not be used
-				Assert.False(obj2.IsManaged);
-				Assert.AreEqual(obj1.abbreviation, obj2.abbreviation);
-				Assert.AreEqual(obj1.name, obj2.name);
-			}
-		}
+                var nonManagedCollectionCopy = managedCollection.NonManagedCopy();
+
+                foreach (var managedObject in nonManagedCollectionCopy)
+                {
+                    Assert.False(managedObject.IsManaged);
+                }
+
+                Assert.True(EnumerablesAreEqual(managedCollection, nonManagedCollectionCopy));
+            }
+        }
+
+        private IList<State> CreateTestCollection()
+        {
+            var testObject1 = new State { name = "XX", abbreviation = "X" };
+            var testObject2 = new State { name = "YY", abbreviation = "Y" };
+            var testObject3 = new State { name = "ZZ", abbreviation = "Z" };
+            var testCollection = new[] { testObject1, testObject2, testObject3 };
+            return testCollection;
+        }
+
+        private bool EnumerablesAreEqual(IEnumerable<State> enumerable1, IEnumerable<State> enumerable2)
+        {
+            var elementCount = enumerable1.Count();
+            if (elementCount != enumerable2.Count()) return false;
+            for (var i = 0; i < elementCount; ++i)
+            {
+                var element1 = enumerable1.ElementAt(i);
+                var element2 = enumerable2.ElementAt(i);
+                if (element1.name != element2.name) return false;
+                if (element1.abbreviation != element2.abbreviation) return false;
+            }
+            return true;
+        }
+
+        [Test]
+        public void NonManagedCopyFromNonManagedGenericType()
+        {
+            var obj1 = new State
+            {
+                name = "ZZ",
+                abbreviation = "Z"
+            };
+            var obj2 = obj1.NonManagedCopy<State>();
+            Assert.False(obj2.IsManaged);
+            // Non-managed objects are never equivalate, this RealmObject.Equals can not be used
+            Assert.AreEqual(obj1.abbreviation, obj2.abbreviation);
+            Assert.AreEqual(obj1.name, obj2.name);
+        }
+
+        [Test]
+        public void NonManagedCopyFromNonManagedRealmObjectType()
+        {
+            var obj1 = new State
+            {
+                name = "ZZ",
+                abbreviation = "Z"
+            };
+            var obj2 = obj1.NonManagedCopy();
+            var obj3 = obj2 as State;
+            // Non-managed objects are never equivalate, this RealmObject.Equals can not be used
+            Assert.False(obj3.IsManaged);
+            Assert.AreEqual(obj1.abbreviation, obj3.abbreviation);
+            Assert.AreEqual(obj1.name, obj3.name);
+        }
+
+        [Test]
+        public void NonManagedCopyFromManagedGenericType()
+        {
+            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+            {
+                State obj1 = null;
+                theRealm.Write(() =>
+                {
+                    var tmp = new State
+                    {
+                        name = "ZZ",
+                        abbreviation = "Z"
+                    };
+                    obj1 = theRealm.Add(tmp);
+                });
+                Assert.True(obj1.IsManaged);
+                var obj2 = obj1.NonManagedCopy<State>();
+                // Non-managed objects are never equivalate, this RealmObject.Equals can not be used
+                Assert.False(obj2.IsManaged);
+                Assert.AreEqual(obj1.abbreviation, obj2.abbreviation);
+                Assert.AreEqual(obj1.name, obj2.name);
+            }
+        }
+
+        [Test]
+        public void NonManagedCopyFromManagedRealmObjectType()
+        {
+            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+            {
+                State obj1 = null;
+                theRealm.Write(() =>
+                {
+                    var tmp = new State
+                    {
+                        name = "ZZ",
+                        abbreviation = "Z"
+                    };
+                    obj1 = theRealm.Add(tmp);
+                });
+                Assert.True(obj1.IsManaged);
+                var obj2 = obj1.NonManagedCopy() as State;
+                // Non-managed objects are never equivalate, this RealmObject.Equals can not be used
+                Assert.False(obj2.IsManaged);
+                Assert.AreEqual(obj1.abbreviation, obj2.abbreviation);
+                Assert.AreEqual(obj1.name, obj2.name);
+            }
+        }
 
 
 #endif
 
-	}
+    }
 }

--- a/src/RealmJson.Shared.Tests/Tests.Shared.cs
+++ b/src/RealmJson.Shared.Tests/Tests.Shared.cs
@@ -9,411 +9,412 @@ using SushiHangover.RealmJson;
 
 namespace RealmJson.Test
 {
-    [TestFixture]
-    public partial class Tests
-    {
-        const string jsonStringSingleState = @"
+	[TestFixture]
+	public partial class Tests
+	{
+		const string jsonStringSingleState = @"
 {
-	""name"": ""Alabama"",
-	""abbreviation"": ""AL""
+    ""name"": ""Alabama"",
+    ""abbreviation"": ""AL""
 }
 ";
 
-        const string jsonStringTwoState = @"
+		const string jsonStringTwoState = @"
 [
-	{
-		""name"": ""Alabama"",
-		""abbreviation"": ""AL""
-	},
+    {
+        ""name"": ""Alabama"",
+        ""abbreviation"": ""AL""
+    },
 {
-		""name"": ""Wyoming"",
-		""abbreviation"": ""WY""
-	}
+        ""name"": ""Wyoming"",
+        ""abbreviation"": ""WY""
+    }
 ]
 ";
 
-        const string jsonStringThreeState = @"
+		const string jsonStringThreeState = @"
 [
-	{
-		""name"": ""Alabama"",
-		""abbreviation"": ""AL""
-	},
-	{
-		""name"": ""Oklahoma"",
-		""abbreviation"": ""OK""
-	},
-	{
-		""name"": ""Wyoming"",
-		""abbreviation"": ""WY""
-	}
+    {
+        ""name"": ""Alabama"",
+        ""abbreviation"": ""AL""
+    },
+    {
+        ""name"": ""Oklahoma"",
+        ""abbreviation"": ""OK""
+    },
+    {
+        ""name"": ""Wyoming"",
+        ""abbreviation"": ""WY""
+    }
 ]
 ";
 
-        public void DeleteRealmDB(string realmDBFullPath)
-        {
-            if (File.Exists(realmDBFullPath))
-            {
-                File.Delete(realmDBFullPath);
-            }
-        }
+		public void DeleteRealmDB(string realmDBFullPath)
+		{
+			if (File.Exists(realmDBFullPath))
+			{
+				File.Delete(realmDBFullPath);
+			}
+		}
 
-        string RealmDBTempPath()
-        {
-            return Path.GetTempFileName();
-        }
+		string RealmDBTempPath()
+		{
+			return Path.GetTempFileName();
+		}
 
-        [SetUp]
-        public void Setup()
-        {
-        }
+		[SetUp]
+		public void Setup()
+		{
+		}
 
-        [TearDown]
-        public void Tear()
-        {
-        }
+		[TearDown]
+		public void Tear()
+		{
+		}
 
 #if !PERF
 
-        [Test]
-        public void CreateObjectFromJson_String()
-        {
-            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-            {
-                var testObject = theRealm.CreateObjectFromJson<StateUnique>(jsonStringSingleState);
-                Assert.IsTrue(testObject.abbreviation == "AL" & testObject.name == "Alabama");
-            }
-        }
+		[Test]
+		public void CreateObjectFromJson_String()
+		{
+			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+			{
+				var testObject = theRealm.CreateObjectFromJson<StateUnique>(jsonStringSingleState);
+				Assert.IsTrue(testObject.abbreviation == "AL" & testObject.name == "Alabama");
+			}
+		}
 
-        [Test]
-        public void CreateObjectFromJson_InTransaction_Stream()
-        {
-            byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringSingleState);
-            using (var stream = new MemoryStream(byteArray))
-            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-            {
-                StateUnique testObject;
-                using (var transaction = theRealm.BeginWrite())
-                {
-                    testObject = theRealm.CreateObjectFromJson<StateUnique>(stream, inTransaction: true);
-                    transaction.Commit();
-                }
-                Assert.IsTrue(testObject.abbreviation == "AL" & testObject.name == "Alabama");
-            }
-        }
-
-        [Test]
-        public void CreateObjectFromJson_InTransaction_RollBack_Stream()
-        {
-            byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringSingleState);
-            using (var stream = new MemoryStream(byteArray))
-            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-            {
-                using (var transaction = theRealm.BeginWrite())
-                {
-                    theRealm.CreateObjectFromJson<StateUnique>(stream, inTransaction: true);
-                    transaction.Rollback();
-                }
-                Assert.IsTrue(theRealm.Find<StateUnique>("AL") == null);
-            }
-        }
-
-        [Test]
-        public void CreateObjectFromJson_Stream()
-        {
-            byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringSingleState);
-            using (var stream = new MemoryStream(byteArray))
-            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-            {
-                var testObject = theRealm.CreateObjectFromJson<StateUnique>(stream);
-                Assert.IsTrue(testObject.abbreviation == "AL" & testObject.name == "Alabama");
-            }
-        }
-
-        public string CreateTestDBFromJson(string jsonString)
-        {
-            var dbFile = RealmDBTempPath();
-            using (var theRealm = Realm.GetInstance(dbFile))
-            {
-                theRealm.CreateAllFromJson<StateUnique>(jsonString);
-            }
-            return dbFile;
-        }
-
-        [Test]
-        public void CreateOrUpdateObjectFromJson_Create_PKisString_String()
-        {
-            var jsonString = @"
+		[Test]
+		public void CreateObjectFromJson_InTransaction_Stream()
+		{
+			byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringSingleState);
+			using (var stream = new MemoryStream(byteArray))
+			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+			{
+				StateUnique testObject;
+				using (var transaction = theRealm.BeginWrite())
 				{
-					""name"": ""NEW"",
-					""abbreviation"": ""NW""
-				}";
-            var dbFile = CreateTestDBFromJson(jsonStringTwoState);
+					testObject = theRealm.CreateObjectFromJson<StateUnique>(stream, inTransaction: true);
+					transaction.Commit();
+				}
+				Assert.IsTrue(testObject.abbreviation == "AL" & testObject.name == "Alabama");
+			}
+		}
 
-            using (var theRealm = Realm.GetInstance(dbFile))
-            {
-                var realmObject = theRealm.CreateOrUpdateObjectFromJson<StateUnique>(jsonString);
-                Assert.IsTrue(realmObject.abbreviation == "NW" & realmObject.name == "NEW");
-            }
-        }
-
-        [Test]
-        public void CreateOrUpdateObjectFromJson_Update_PKisString_String()
-        {
-            var jsonString = @"
+		[Test]
+		public void CreateObjectFromJson_InTransaction_RollBack_Stream()
+		{
+			byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringSingleState);
+			using (var stream = new MemoryStream(byteArray))
+			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+			{
+				using (var transaction = theRealm.BeginWrite())
 				{
-					""name"": ""UPDATED"",
-					""abbreviation"": ""OK""
+					theRealm.CreateObjectFromJson<StateUnique>(stream, inTransaction: true);
+					transaction.Rollback();
+				}
+				Assert.IsTrue(theRealm.Find<StateUnique>("AL") == null);
+			}
+		}
+
+		[Test]
+		public void CreateObjectFromJson_Stream()
+		{
+			byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringSingleState);
+			using (var stream = new MemoryStream(byteArray))
+			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+			{
+				var testObject = theRealm.CreateObjectFromJson<StateUnique>(stream);
+				Assert.IsTrue(testObject.abbreviation == "AL" & testObject.name == "Alabama");
+			}
+		}
+
+		public string CreateTestDBFromJson(string jsonString)
+		{
+			var dbFile = RealmDBTempPath();
+			using (var theRealm = Realm.GetInstance(dbFile))
+			{
+				theRealm.CreateAllFromJson<StateUnique>(jsonString);
+			}
+			return dbFile;
+		}
+
+		[Test]
+		public void CreateOrUpdateObjectFromJson_Create_PKisString_String()
+		{
+			var jsonString = @"
+				{
+				    ""name"": ""NEW"",
+				    ""abbreviation"": ""NW""
+				}";
+			var dbFile = CreateTestDBFromJson(jsonStringTwoState);
+
+			using (var theRealm = Realm.GetInstance(dbFile))
+			{
+				var realmObject = theRealm.CreateOrUpdateObjectFromJson<StateUnique>(jsonString);
+				Assert.IsTrue(realmObject.abbreviation == "NW" & realmObject.name == "NEW");
+			}
+		}
+
+		[Test]
+		public void CreateOrUpdateObjectFromJson_Update_PKisString_String()
+		{
+			var jsonString = @"
+				{
+				    ""name"": ""UPDATED"",
+				    ""abbreviation"": ""OK""
 				}";
 
-            var dbFile = CreateTestDBFromJson(jsonStringThreeState);
+			var dbFile = CreateTestDBFromJson(jsonStringThreeState);
 
-            using (var theRealm = Realm.GetInstance(dbFile))
-            {
-                var realmObject = theRealm.CreateOrUpdateObjectFromJson<StateUnique>(jsonString);
-                Assert.IsTrue(realmObject.name == "UPDATED");
-            }
-        }
+			using (var theRealm = Realm.GetInstance(dbFile))
+			{
+				var realmObject = theRealm.CreateOrUpdateObjectFromJson<StateUnique>(jsonString);
+				Assert.IsTrue(realmObject.name == "UPDATED");
+			}
+		}
 
-        [Test]
-        public void CreateAllFromJson_String()
-        {
-            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-            {
-                theRealm.CreateAllFromJson<StateUnique>(jsonStringThreeState);
-                Assert.AreEqual(3, theRealm.All<StateUnique>().Count());
-            }
-        }
+		[Test]
+		public void CreateAllFromJson_String()
+		{
+			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+			{
+				theRealm.CreateAllFromJson<StateUnique>(jsonStringThreeState);
+				Assert.AreEqual(3, theRealm.All<StateUnique>().Count());
+			}
+		}
 
-        [Test]
-        public void CreateAllFromJson_Stream()
-        {
-            byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringTwoState);
-            using (var stream = new MemoryStream(byteArray))
-            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-            {
-                theRealm.CreateAllFromJson<StateUnique>(stream);
-                Assert.AreEqual(2, theRealm.All<StateUnique>().Count());
+		[Test]
+		public void CreateAllFromJson_Stream()
+		{
+			byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringTwoState);
+			using (var stream = new MemoryStream(byteArray))
+			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+			{
+				theRealm.CreateAllFromJson<StateUnique>(stream);
+				Assert.AreEqual(2, theRealm.All<StateUnique>().Count());
 
-                // Did the records get created properly from the steam?
-                Assert.IsTrue(theRealm.All<StateUnique>().Where((StateUnique s) => s.abbreviation == "AL").Any());
-                Assert.IsTrue(theRealm.All<StateUnique>().Last().abbreviation == "WY");
-            }
-        }
+				// Did the records get created properly from the steam?
+				Assert.IsTrue(theRealm.All<StateUnique>().Where((StateUnique s) => s.abbreviation == "AL").Any());
+				Assert.IsTrue(theRealm.All<StateUnique>().Last().abbreviation == "WY");
+			}
+		}
 
-        [Test]
-        public void CreateAllFromJsonViaAutoMapperFromJson__NewRecords_Stream()
-        {
-            byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringTwoState);
-            using (var stream = new MemoryStream(byteArray))
-            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-            {
-                theRealm.CreateAllFromJsonViaAutoMapper<StateUnique>(stream);
-                Assert.AreEqual(2, theRealm.All<StateUnique>().Count());
+		[Test]
+		public void CreateAllFromJsonViaAutoMapperFromJson__NewRecords_Stream()
+		{
+			byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringTwoState);
+			using (var stream = new MemoryStream(byteArray))
+			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+			{
+				theRealm.CreateAllFromJsonViaAutoMapper<StateUnique>(stream);
+				Assert.AreEqual(2, theRealm.All<StateUnique>().Count());
 
-                // Did the records get AutoMapped properly from the steam?
-                Assert.IsTrue(theRealm.All<StateUnique>().Where((StateUnique s) => s.abbreviation == "AL").Any());
-                Assert.IsTrue(theRealm.All<StateUnique>().Last().abbreviation == "WY");
-            }
-        }
+				// Did the records get AutoMapped properly from the steam?
+				Assert.IsTrue(theRealm.All<StateUnique>().Where((StateUnique s) => s.abbreviation == "AL").Any());
+				Assert.IsTrue(theRealm.All<StateUnique>().Last().abbreviation == "WY");
+			}
+		}
 
-        [Test]
-        public void CreateAllFromJsonViaAutoMapperFromJson__UpdateRecords_Stream()
-        {
-            var dbFile = CreateTestDBFromJson(jsonStringTwoState);
-            byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringThreeState);
-            using (var stream = new MemoryStream(byteArray))
-            using (var theRealm = Realm.GetInstance(dbFile))
-            {
-                Assert.AreEqual(2, theRealm.All<StateUnique>().Count());
-                theRealm.CreateAllFromJsonViaAutoMapper<StateUnique>(stream);
-                Assert.AreEqual(3, theRealm.All<StateUnique>().Count());
+		[Test]
+		public void CreateAllFromJsonViaAutoMapperFromJson__UpdateRecords_Stream()
+		{
+			var dbFile = CreateTestDBFromJson(jsonStringTwoState);
+			byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringThreeState);
+			using (var stream = new MemoryStream(byteArray))
+			using (var theRealm = Realm.GetInstance(dbFile))
+			{
+				Assert.AreEqual(2, theRealm.All<StateUnique>().Count());
+				theRealm.CreateAllFromJsonViaAutoMapper<StateUnique>(stream);
+				Assert.AreEqual(3, theRealm.All<StateUnique>().Count());
 
-                // Did the "new" record get AutoMapped properly from the steam?
-                Assert.IsTrue(theRealm.All<StateUnique>().Where((StateUnique s) => s.abbreviation == "OK").Any());
-            }
-        }
+				// Did the "new" record get AutoMapped properly from the steam?
+				Assert.IsTrue(theRealm.All<StateUnique>().Where((StateUnique s) => s.abbreviation == "OK").Any());
+			}
+		}
 
-        [Test]
-        public void CreateAllFromJsonViaAutoMapperFromJson__UpdateRecords__InTrans_Stream()
-        {
-            var dbFile = CreateTestDBFromJson(jsonStringTwoState);
-            byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringThreeState);
-            using (var stream = new MemoryStream(byteArray))
-            using (var theRealm = Realm.GetInstance(dbFile))
-            {
-                Assert.AreEqual(2, theRealm.All<StateUnique>().Count());
-                using (var transaction = theRealm.BeginWrite())
-                {
-                    theRealm.CreateAllFromJsonViaAutoMapper<StateUnique>(stream, true);
-                    transaction.Commit();
-                }
-                Assert.AreEqual(3, theRealm.All<StateUnique>().Count());
-                // Did the "new" record get AutoMapped properly from the steam?
-                Assert.IsTrue(theRealm.All<StateUnique>().Where((StateUnique s) => s.abbreviation == "OK").Any());
-            }
-        }
+		[Test]
+		public void CreateAllFromJsonViaAutoMapperFromJson__UpdateRecords__InTrans_Stream()
+		{
+			var dbFile = CreateTestDBFromJson(jsonStringTwoState);
+			byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringThreeState);
+			using (var stream = new MemoryStream(byteArray))
+			using (var theRealm = Realm.GetInstance(dbFile))
+			{
+				Assert.AreEqual(2, theRealm.All<StateUnique>().Count());
+				using (var transaction = theRealm.BeginWrite())
+				{
+					theRealm.CreateAllFromJsonViaAutoMapper<StateUnique>(stream, true);
+					transaction.Commit();
+				}
+				Assert.AreEqual(3, theRealm.All<StateUnique>().Count());
+				// Did the "new" record get AutoMapped properly from the steam?
+				Assert.IsTrue(theRealm.All<StateUnique>().Where((StateUnique s) => s.abbreviation == "OK").Any());
+			}
+		}
 
-        [Test]
-        public void CreateAllFromJson_InvalidStream()
-        {
-            var jsonStringInvalid = @"";
-            byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringInvalid);
-            using (var stream = new MemoryStream(byteArray))
-            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-            {
-                Assert.That(() => theRealm.CreateAllFromJson<StateUnique>(stream),
-                    Throws.Exception
-                        .TypeOf<Exception>()
-                        .With.Property("Message")
-                        .EqualTo(RealmDoesJson.ExMalFormeJsonMessage)
-               );
-            }
-        }
-        [Test]
-        public void NonManagedCollectionCopyFromNonManagedGenericType()
-        {
-            var nonManagedCollection = CreateTestCollection();
-            var nonManagedCollectionCopy = nonManagedCollection.NonManagedCopy();
-            Assert.False(nonManagedCollectionCopy.All(element => element.IsManaged));
-            Assert.True(EnumerablesAreEqual(nonManagedCollectionCopy, nonManagedCollection));
-        }
+		[Test]
+		public void CreateAllFromJson_InvalidStream()
+		{
+			var jsonStringInvalid = @"";
+			byte[] byteArray = Encoding.UTF8.GetBytes(jsonStringInvalid);
+			using (var stream = new MemoryStream(byteArray))
+			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+			{
+				Assert.That(() => theRealm.CreateAllFromJson<StateUnique>(stream),
+					Throws.Exception
+						.TypeOf<Exception>()
+						.With.Property("Message")
+						.EqualTo(RealmDoesJson.ExMalFormeJsonMessage)
+			   );
+			}
+		}
 
-        [Test]
-        public void NonManagedCollectionCopyFromManagedGenericType()
-        {
-            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-            {
-                theRealm.Write(() =>
-                {
-                    var nonManagedCollection = CreateTestCollection();
-                    foreach (var item in nonManagedCollection)
-                    {
-                        theRealm.Add(item);
-                    }
-                });
+		[Test]
+		public void NonManagedCollectionCopyFromNonManagedGenericType()
+		{
+			var nonManagedCollection = CreateTestCollection();
+			var nonManagedCollectionCopy = nonManagedCollection.NonManagedCopy();
+			Assert.False(nonManagedCollectionCopy.All(element => element.IsManaged));
+			Assert.True(EnumerablesAreEqual(nonManagedCollectionCopy, nonManagedCollection));
+		}
 
-                var managedCollection = theRealm.All<State>();
+		[Test]
+		public void NonManagedCollectionCopyFromManagedGenericType()
+		{
+			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+			{
+				theRealm.Write(() =>
+				{
+					var nonManagedCollection = CreateTestCollection();
+					foreach (var item in nonManagedCollection)
+					{
+						theRealm.Add(item);
+					}
+				});
 
-                foreach (var managedObject in managedCollection)
-                {
-                    Assert.True(managedObject.IsManaged);
-                }
+				var managedCollection = theRealm.All<State>();
 
-                var nonManagedCollectionCopy = managedCollection.NonManagedCopy();
+				foreach (var managedObject in managedCollection)
+				{
+					Assert.True(managedObject.IsManaged);
+				}
 
-                foreach (var managedObject in nonManagedCollectionCopy)
-                {
-                    Assert.False(managedObject.IsManaged);
-                }
+				var nonManagedCollectionCopy = managedCollection.NonManagedCopy();
 
-                Assert.True(EnumerablesAreEqual(managedCollection, nonManagedCollectionCopy));
-            }
-        }
+				foreach (var managedObject in nonManagedCollectionCopy)
+				{
+					Assert.False(managedObject.IsManaged);
+				}
 
-        private IList<State> CreateTestCollection()
-        {
-            var testObject1 = new State { name = "XX", abbreviation = "X" };
-            var testObject2 = new State { name = "YY", abbreviation = "Y" };
-            var testObject3 = new State { name = "ZZ", abbreviation = "Z" };
-            var testCollection = new[] { testObject1, testObject2, testObject3 };
-            return testCollection;
-        }
+				Assert.True(EnumerablesAreEqual(managedCollection, nonManagedCollectionCopy));
+			}
+		}
 
-        private bool EnumerablesAreEqual(IEnumerable<State> enumerable1, IEnumerable<State> enumerable2)
-        {
-            var elementCount = enumerable1.Count();
-            if (elementCount != enumerable2.Count()) return false;
-            for (var i = 0; i < elementCount; ++i)
-            {
-                var element1 = enumerable1.ElementAt(i);
-                var element2 = enumerable2.ElementAt(i);
-                if (element1.name != element2.name) return false;
-                if (element1.abbreviation != element2.abbreviation) return false;
-            }
-            return true;
-        }
+		private IList<State> CreateTestCollection()
+		{
+			var testObject1 = new State { name = "XX", abbreviation = "X" };
+			var testObject2 = new State { name = "YY", abbreviation = "Y" };
+			var testObject3 = new State { name = "ZZ", abbreviation = "Z" };
+			var testCollection = new[] { testObject1, testObject2, testObject3 };
+			return testCollection;
+		}
 
-        [Test]
-        public void NonManagedCopyFromNonManagedGenericType()
-        {
-            var obj1 = new State
-            {
-                name = "ZZ",
-                abbreviation = "Z"
-            };
-            var obj2 = obj1.NonManagedCopy<State>();
-            Assert.False(obj2.IsManaged);
-            // Non-managed objects are never equivalate, this RealmObject.Equals can not be used
-            Assert.AreEqual(obj1.abbreviation, obj2.abbreviation);
-            Assert.AreEqual(obj1.name, obj2.name);
-        }
+		private bool EnumerablesAreEqual(IEnumerable<State> enumerable1, IEnumerable<State> enumerable2)
+		{
+			var elementCount = enumerable1.Count();
+			if (elementCount != enumerable2.Count()) return false;
+			for (var i = 0; i < elementCount; ++i)
+			{
+				var element1 = enumerable1.ElementAt(i);
+				var element2 = enumerable2.ElementAt(i);
+				if (element1.name != element2.name) return false;
+				if (element1.abbreviation != element2.abbreviation) return false;
+			}
+			return true;
+		}
 
-        [Test]
-        public void NonManagedCopyFromNonManagedRealmObjectType()
-        {
-            var obj1 = new State
-            {
-                name = "ZZ",
-                abbreviation = "Z"
-            };
-            var obj2 = obj1.NonManagedCopy();
-            var obj3 = obj2 as State;
-            // Non-managed objects are never equivalate, this RealmObject.Equals can not be used
-            Assert.False(obj3.IsManaged);
-            Assert.AreEqual(obj1.abbreviation, obj3.abbreviation);
-            Assert.AreEqual(obj1.name, obj3.name);
-        }
+		[Test]
+		public void NonManagedCopyFromNonManagedGenericType()
+		{
+			var obj1 = new State
+			{
+				name = "ZZ",
+				abbreviation = "Z"
+			};
+			var obj2 = obj1.NonManagedCopy<State>();
+			Assert.False(obj2.IsManaged);
+			// Non-managed objects are never equivalate, this RealmObject.Equals can not be used
+			Assert.AreEqual(obj1.abbreviation, obj2.abbreviation);
+			Assert.AreEqual(obj1.name, obj2.name);
+		}
 
-        [Test]
-        public void NonManagedCopyFromManagedGenericType()
-        {
-            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-            {
-                State obj1 = null;
-                theRealm.Write(() =>
-                {
-                    var tmp = new State
-                    {
-                        name = "ZZ",
-                        abbreviation = "Z"
-                    };
-                    obj1 = theRealm.Add(tmp);
-                });
-                Assert.True(obj1.IsManaged);
-                var obj2 = obj1.NonManagedCopy<State>();
-                // Non-managed objects are never equivalate, this RealmObject.Equals can not be used
-                Assert.False(obj2.IsManaged);
-                Assert.AreEqual(obj1.abbreviation, obj2.abbreviation);
-                Assert.AreEqual(obj1.name, obj2.name);
-            }
-        }
+		[Test]
+		public void NonManagedCopyFromNonManagedRealmObjectType()
+		{
+			var obj1 = new State
+			{
+				name = "ZZ",
+				abbreviation = "Z"
+			};
+			var obj2 = obj1.NonManagedCopy();
+			var obj3 = obj2 as State;
+			// Non-managed objects are never equivalate, this RealmObject.Equals can not be used
+			Assert.False(obj3.IsManaged);
+			Assert.AreEqual(obj1.abbreviation, obj3.abbreviation);
+			Assert.AreEqual(obj1.name, obj3.name);
+		}
 
-        [Test]
-        public void NonManagedCopyFromManagedRealmObjectType()
-        {
-            using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
-            {
-                State obj1 = null;
-                theRealm.Write(() =>
-                {
-                    var tmp = new State
-                    {
-                        name = "ZZ",
-                        abbreviation = "Z"
-                    };
-                    obj1 = theRealm.Add(tmp);
-                });
-                Assert.True(obj1.IsManaged);
-                var obj2 = obj1.NonManagedCopy() as State;
-                // Non-managed objects are never equivalate, this RealmObject.Equals can not be used
-                Assert.False(obj2.IsManaged);
-                Assert.AreEqual(obj1.abbreviation, obj2.abbreviation);
-                Assert.AreEqual(obj1.name, obj2.name);
-            }
-        }
+		[Test]
+		public void NonManagedCopyFromManagedGenericType()
+		{
+			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+			{
+				State obj1 = null;
+				theRealm.Write(() =>
+				{
+					var tmp = new State
+					{
+						name = "ZZ",
+						abbreviation = "Z"
+					};
+					obj1 = theRealm.Add(tmp);
+				});
+				Assert.True(obj1.IsManaged);
+				var obj2 = obj1.NonManagedCopy<State>();
+				// Non-managed objects are never equivalate, this RealmObject.Equals can not be used
+				Assert.False(obj2.IsManaged);
+				Assert.AreEqual(obj1.abbreviation, obj2.abbreviation);
+				Assert.AreEqual(obj1.name, obj2.name);
+			}
+		}
+
+		[Test]
+		public void NonManagedCopyFromManagedRealmObjectType()
+		{
+			using (var theRealm = Realm.GetInstance(RealmDBTempPath()))
+			{
+				State obj1 = null;
+				theRealm.Write(() =>
+				{
+					var tmp = new State
+					{
+						name = "ZZ",
+						abbreviation = "Z"
+					};
+					obj1 = theRealm.Add(tmp);
+				});
+				Assert.True(obj1.IsManaged);
+				var obj2 = obj1.NonManagedCopy() as State;
+				// Non-managed objects are never equivalate, this RealmObject.Equals can not be used
+				Assert.False(obj2.IsManaged);
+				Assert.AreEqual(obj1.abbreviation, obj2.abbreviation);
+				Assert.AreEqual(obj1.name, obj2.name);
+			}
+		}
 
 
 #endif
 
-    }
+	}
 }


### PR DESCRIPTION
This should come in handy. Simple extension methods to simplify creating non-managed copy of Realm query results or lists.